### PR TITLE
Fix bug in GameObjectBase.AbsolutePosition

### DIFF
--- a/Jypeli/GameObjects/GameObject/GameObjectBase.cs
+++ b/Jypeli/GameObjects/GameObject/GameObjectBase.cs
@@ -387,6 +387,38 @@ namespace Jypeli.GameObjects
         }
 
         /// <summary>
+        /// Olion koordinaatiston X-yksikkökantavektori.
+        /// </summary>
+        public Vector UnitX
+        {
+            get { return Vector.FromAngle( Angle ); }
+        }
+
+        /// <summary>
+        /// Olion koordinaatiston Y-yksikkökantavektori.
+        /// </summary>
+        public Vector UnitY
+        {
+            get { return UnitX.LeftNormal; }
+        }
+
+        /// <summary>
+        /// Olion koordinaatiston absoluuttinen X-yksikkökantavektori.
+        /// </summary>
+        public Vector AbsoluteUnitX
+        {
+            get { return Vector.FromAngle( AbsoluteAngle ); }
+        }
+
+        /// <summary>
+        /// Olion koordinaatiston absoluuttinen Y-yksikkökantavektori.
+        /// </summary>
+        public Vector AbsoluteUnitY
+        {
+            get { return AbsoluteUnitX.LeftNormal; }
+        }
+
+        /// <summary>
         /// Animaatio. Voi olla <c>null</c>, jolloin piirretään vain väri.
         /// </summary>
         public abstract Animation Animation { get; set; }

--- a/Jypeli/GameObjects/GameObject/GameObjectBase.cs
+++ b/Jypeli/GameObjects/GameObject/GameObjectBase.cs
@@ -254,13 +254,18 @@ namespace Jypeli.GameObjects
             get
             {
                 if ( Parent != null )
-                    return Parent.AbsolutePosition + this.Position;
+                    return Parent.AbsolutePosition + Parent.AbsoluteUnitX * Position.X + Parent.AbsoluteUnitY * Position.Y;
                 return Position;
             }
             set
             {
                 if ( Parent != null )
-                    Position = value - Parent.AbsolutePosition;
+                {
+                    var rawPosition = value - Parent.AbsolutePosition;
+                    double x = Vector.DotProduct(Parent.AbsoluteUnitX, rawPosition);
+                    double y = Vector.DotProduct(Parent.AbsoluteUnitY, rawPosition);
+                    Position = new Vector(x, y);
+                }
                 else
                     Position = value;
             }

--- a/Jypeli/GameObjects/GameObject/IGameObject.cs
+++ b/Jypeli/GameObjects/GameObject/IGameObject.cs
@@ -28,6 +28,10 @@ namespace Jypeli
 
         Vector AbsolutePosition { get; set; }
         Angle AbsoluteAngle { get; set; }
+        Vector UnitX { get; }
+        Vector UnitY { get; }
+        Vector AbsoluteUnitX { get; }
+        Vector AbsoluteUnitY { get; }
         
         Animation Animation { get; set; }
         Image Image { get; set; }


### PR DESCRIPTION
The position calculated in the accessors of GameObjectBase.AbsolutePosition was erroneous because the parent object rotation was neglected. This bug appears to be positively ancient - how odd that none of the students working with the library have complained about it before.