### PR TITLE
Fix bug in SynchronousList.Update

### DIFF
--- a/Jypeli/DataTypes/SynchronousList.cs
+++ b/Jypeli/DataTypes/SynchronousList.cs
@@ -280,7 +280,7 @@ namespace Jypeli
 
                 if ( DestroyableItem != null && DestroyableItem.IsDestroyed )
                     Remove( item );
-                else if ( UpdatableItem != null && UpdatableItem.IsUpdated )
+                if ( UpdatableItem != null && UpdatableItem.IsUpdated )
                     UpdatableItem.Update( time );
             }
 


### PR DESCRIPTION
Destroyed GameObjects were denied their very last update, which caused
their (destroyed) children to become effectively unreachable and never
removed.

(The logic and sequencing of game state updates is rather convoluted with lots of events triggered, so there may still be further bugs. However, this change fixes at least some of them, and should not be able to cause any new ones - after all, this just lets the to-be-removed items to update their state one last time, allowing their children to be recursively removed.)