### PR TITLE
Fix bugs in MultiSelectWindow

### DIFF
--- a/Jypeli/Helpers/ListHelpers.cs
+++ b/Jypeli/Helpers/ListHelpers.cs
@@ -149,6 +149,9 @@ namespace Jypeli
             return outList;
         }
 
+        public static void AddItems<T>(this List<T> list, params T[] items) =>
+            list.AddRange(items);
+
         public static void RemoveAll<T>( this List<T> items, Predicate<T> pred )
         {
             // Huom/TK: RemoveAll-metodi on jo olemassa, mutta sitä ei ole toteutettu X360/WP7-alustoille.

--- a/Jypeli/Widgets/MultiSelectWindow.cs
+++ b/Jypeli/Widgets/MultiSelectWindow.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Jypeli.Controls;
 using Jypeli.GameObjects;
 
@@ -12,7 +13,7 @@ namespace Jypeli
         static readonly Key[] keys = { Key.D1, Key.D2, Key.D3, Key.D4, Key.D5, Key.D6, Key.D7, Key.D8, Key.D9, Key.D0 };
 
         private int _defaultCancel = 0;
-        private ListenContext defaultContext = null;
+        private List<Listener> _defaultListeners = new List<Listener>(4);
 
         private int _selectedIndex = -1;
         private Color _selectedColor = Color.Black;
@@ -268,18 +269,15 @@ namespace Jypeli
 
         private void AddDefaultControls()
         {
-            if ( defaultContext != null )
-            {
-                defaultContext.Destroy();
-                defaultContext = null;
-            }
+            _defaultListeners.ForEach(l => l.Destroy());
+            _defaultListeners.Clear();
 
             if ( _defaultCancel >= 0 && _defaultCancel < Buttons.Length )
             {
-                defaultContext = this.ControlContext.CreateSubcontext();
-                Game.Instance.PhoneBackButton.Listen( Buttons[_defaultCancel].Click, null ).InContext( defaultContext );
-                Game.Instance.Keyboard.Listen( Key.Escape, ButtonState.Pressed, Buttons[_defaultCancel].Click, null ).InContext( defaultContext );
-                Game.Instance.ControllerOne.Listen( Button.B, ButtonState.Pressed, Buttons[_defaultCancel].Click, null ).InContext( defaultContext );
+                var l1 = Game.Instance.PhoneBackButton.Listen( Buttons[_defaultCancel].Click, null ).InContext( this );
+                var l2 = Game.Instance.Keyboard.Listen( Key.Escape, ButtonState.Pressed, Buttons[_defaultCancel].Click, null ).InContext( this );
+                var l3 = Game.Instance.ControllerOne.Listen( Button.B, ButtonState.Pressed, Buttons[_defaultCancel].Click, null ).InContext( this );
+                _defaultListeners.AddItems(l1, l2, l3);
             }
         }
 

--- a/Jypeli/Widgets/MultiSelectWindow.cs
+++ b/Jypeli/Widgets/MultiSelectWindow.cs
@@ -247,7 +247,7 @@ namespace Jypeli
 
             for ( int i = 0; i < Math.Min( Buttons.Length, keys.Length ); i++ )
             {
-                Keyboard.Listen( keys[i], ButtonState.Pressed, ButtonClicked, null, i ).InContext( this );
+                Keyboard.Listen(keys[i], ButtonState.Pressed, SelectButton, null, i).InContext(this);
             }
 
             Action selectPrev = delegate { SelectButton( _selectedIndex > 0 ? _selectedIndex - 1 : Buttons.Length - 1 ); };


### PR DESCRIPTION
The number key button selection & default cancel action didn't work. This fixes them.

Also, the listeners created by MultiSelectWindow were never destroyed, and they would just live eternally in the SynchronousList for listeners in each Controller. They wouldn't get invoked if the window were removed since there is a check for that, but new ones would be added to the list every time the window is shown.

MultiSelectWindow is not the only class with this type of leak - e.g. Window itself has it too. Since there is no mechanism for automatically removing listeners whose associated context is destroyed, the listeners must be destroyed manually by any object that creates them.

I'll go through the Listen calls and submit pull requests accordingly, since there are not that many of them, but maybe in the future an automatic listener cleanup system should be added.