### PR TITLE
Fixed bugs in Layers.cs

### DIFF
--- a/Jypeli/Game/Layers.cs
+++ b/Jypeli/Game/Layers.cs
@@ -239,10 +239,10 @@ namespace Jypeli
         /// </summary>
         public void ResetLayers()
         {
-            ClearGameObjects();
-
             foreach (var layer in Layers)
             {
+                layer.Clear();
+
                 // Jos muutoksia ei päivitetä, niin taso ei ehdi oikeasti hävittää
                 // olioitaan, koska InitLayers luo uudet tasot ja sen jälkeen
                 // vanhat tasot muuttuvat roskaksi - siten esim. peliolioiden

--- a/Jypeli/Game/Layers.cs
+++ b/Jypeli/Game/Layers.cs
@@ -229,7 +229,9 @@ namespace Jypeli
                 layer.Clear();
             }
 
-            addMessageDisplay();
+            // Layer.Clear on synkronoitu operaatio, joten viestinäyttöä ei ole vielä poistettu.
+            // Siksi viestinäytön palauttaminen on lisättävä operaatiojonoon pakotetusti.
+            addMessageDisplay(force: true);
         }
 
         /// <summary>

--- a/Jypeli/Game/Widgets.cs
+++ b/Jypeli/Game/Widgets.cs
@@ -8,7 +8,7 @@
         /// <value>Viestinäyttö.</value>
         public MessageDisplay MessageDisplay { get; set; }
 
-        private void addMessageDisplay()
+        private void addMessageDisplay(bool force = false)
         {
             if (MessageDisplay == null)
             {
@@ -18,7 +18,7 @@
             else
                 MessageDisplay.Clear();
 
-            if ( !MessageDisplay.IsAddedToGame )
+            if ( !MessageDisplay.IsAddedToGame || force)
                 Add( MessageDisplay );
         }
 


### PR DESCRIPTION
Fixes #10.

It's worth noting that Game.ResetLayers calls Layer.ApplyChanges, bypassing synchronization.
Thus ResetLayers (and by extension, e.g. Game.ClearAll) can't be called while iterating the
SynchronousLists of the layers. For example, calling Game.Instance.ClearAll from the Update function of a game object will throw an exception.

On the other hand, Game.ClearGameObjects should work from anywhere with this fix.