### PR TITLE
Fix transformation bug in ScreenView.ToXnaCoords

### DIFF
--- a/Jypeli/Graphics/Renderer.cs
+++ b/Jypeli/Graphics/Renderer.cs
@@ -290,7 +290,7 @@ namespace Jypeli
         public static void DrawText( string text, ref Matrix transformation, Font font, Color color )
         {
             Vector textSize = (Vector)font.XnaFont.MeasureString( text );
-            Matrix m = ScreenView.ToXnaCoords( transformation, Game.Screen.Size, textSize );
+            Matrix m = ScreenView.ToXnaCoords(ref transformation, Game.Screen.Size, textSize );
 
             SpriteBatch spriteBatch = Graphics.SpriteBatch;
             spriteBatch.Begin( SpriteSortMode.FrontToBack, BlendState.AlphaBlend, SamplerState.LinearClamp, currentStencilState, RasterizerState.CullCounterClockwise, null, m );

--- a/Jypeli/Graphics/View.cs
+++ b/Jypeli/Graphics/View.cs
@@ -376,17 +376,14 @@ namespace Jypeli
         /// <param name="screenSize"></param>
         /// <param name="scale"></param>
         /// <returns></returns>
-        internal static Matrix ToXnaCoords( Matrix matrix, Vector screenSize, Vector scale )
+        internal static Matrix ToXnaCoords(ref Matrix matrix, Vector screenSize, Vector scale)
         {
-            float xnamat_M41 = xToXna( matrix.M41, (float)screenSize.X, matrix.M11 * (float)scale.X );
-            float xnamat_M42 = yToXna( matrix.M42, (float)screenSize.Y, matrix.M22 * (float)scale.Y );
+            // Keskitetään sprite ruudulla, mutta toteutetaan alkuperäinen muunnos Jypelin koordinaateissa.
+            var centralize = Matrix.CreateTranslation((screenSize - scale) / 2);
+            var toXna      = Matrix.CreateScale(1, -1, 1) * Matrix.CreateTranslation(screenSize / 2);
+            var toJypeli   = Matrix.Invert(toXna);
 
-            return new Matrix(
-                matrix.M11, matrix.M12, matrix.M13, matrix.M14,
-                matrix.M21, matrix.M22, matrix.M23, matrix.M24,
-                matrix.M31, matrix.M32, matrix.M33, matrix.M34,
-                xnamat_M41, xnamat_M42, matrix.M43, matrix.M44
-            );
+            return centralize * toJypeli * matrix * toXna;
         }
 
         /// <summary>

--- a/Jypeli/Widgets/Label.cs
+++ b/Jypeli/Widgets/Label.cs
@@ -482,7 +482,7 @@ namespace Jypeli
         {
             Matrix m = Matrix.CreateScale( _textScale )
                 * Matrix.CreateTranslation( (float)GetHorizontalAlignment(), (float)GetVerticalAlignment(), 0 )
-                * Matrix.CreateRotationZ( (float)-Angle.Radians )
+                * Matrix.CreateRotationZ( (float)Angle.Radians )
                 * Matrix.CreateTranslation( (float)Position.X, (float)Position.Y, 0 )
                 * parentTransformation;
 

--- a/Jypeli/Widgets/LetterPicker.cs
+++ b/Jypeli/Widgets/LetterPicker.cs
@@ -232,7 +232,7 @@ namespace Jypeli
             for ( int i = -1; i <= 1; i++ )
             {
                 Matrix m = Matrix.CreateScale( TextScale )
-                           * Matrix.CreateRotationZ( (float)-Angle.Radians )
+                           * Matrix.CreateRotationZ( (float)Angle.Radians )
                            * Matrix.CreateTranslation( (float)Position.X, (float)( Position.Y - ( i - yDelta ) * TextSize.Y ), 0 )
                            * parentTransformation;
 


### PR DESCRIPTION
The conversion of transformation matrices from game coordinates to
screen coordinates didn't work properly for matrices with a rotation
component.

Pure translations worked fine, but if any object – for example a window or a button – with attached labels was rotated, the label transformations would make absolutely no sense.

Both Label and LetterPicker tried to apply a correction for this by inverting the rotation angle, but this only worked if the labels had no parent transformation (hardly ever, that is), and even then only partially, since the rotation centre would still be slightly wrong.