### PR TITLE
Fix input listener leaks in Widgets

### DIFF
--- a/Jypeli/GameObjects/Widget/Control.cs
+++ b/Jypeli/GameObjects/Widget/Control.cs
@@ -6,6 +6,11 @@ namespace Jypeli
     public partial class Widget
     {
         private ListenContext _context = new ListenContext();
+
+        /// <summary>
+        /// Tähän listaan lisätyt kuuntelijat tuhotaan automaattisesti
+        /// kun Widget poistetaan pelistä.
+        /// </summary>
         internal List<Listener> associatedListeners = new List<Listener>();
 
         public ListenContext ControlContext { get { return _context; } }
@@ -23,6 +28,8 @@ namespace Jypeli
 
             Objects.ItemAdded += InitChildContext;
             Objects.ItemRemoved += ResetChildContext;
+
+            Removed += RemoveListeners;
         }
 
         private void InitChildContext( GameObject child )
@@ -39,6 +46,12 @@ namespace Jypeli
             if ( ctxChild == null ) return;
             ctxChild.ControlContext.parentObject = null;
             ctxChild.ControlContext.parentContext = null;
+        }
+
+        private void RemoveListeners()
+        {
+            associatedListeners.ForEach(l => l.Destroy());
+            associatedListeners.Clear();
         }
     }
 }

--- a/Jypeli/Widgets/CustomQueryWindow.cs
+++ b/Jypeli/Widgets/CustomQueryWindow.cs
@@ -148,10 +148,11 @@ namespace Jypeli
         {
 #if WINDOWS_PHONE || ANDROID
             if ( !OkButtonOnPhone )
-                Game.Instance.TouchPanel.Listen( ButtonState.Pressed, delegate { Close(); }, null ).InContext( this );
+                var l = Game.Instance.TouchPanel.Listen( ButtonState.Pressed, delegate { Close(); }, null ).InContext( this );
 #else
-            Game.Instance.Keyboard.Listen( Key.Enter, ButtonState.Pressed, OKButton.Click, null ).InContext( this );
+            var l = Game.Instance.Keyboard.Listen( Key.Enter, ButtonState.Pressed, OKButton.Click, null ).InContext( this );
 #endif
+            associatedListeners.Add(l);
         }
     }
 }

--- a/Jypeli/Widgets/HighScoreWindow.cs
+++ b/Jypeli/Widgets/HighScoreWindow.cs
@@ -148,7 +148,8 @@ namespace Jypeli.Widgets
 
         void AddControls()
         {
-            Jypeli.Game.Instance.PhoneBackButton.Listen( Close, null ).InContext( this );
+            var l = Jypeli.Game.Instance.PhoneBackButton.Listen( Close, null ).InContext( this );
+            associatedListeners.Add(l);
         }
 
         void showNameWindow()

--- a/Jypeli/Widgets/InputBox.cs
+++ b/Jypeli/Widgets/InputBox.cs
@@ -156,7 +156,8 @@ namespace Jypeli
 #endif
 
             Game.Instance.Window.TextInput += InputText;
-			Game.Instance.Keyboard.Listen(Key.Back, ButtonState.Pressed, EraseText, null).InContext(this);
+			var l = Game.Instance.Keyboard.Listen(Key.Back, ButtonState.Pressed, EraseText, null).InContext(this);
+            associatedListeners.Add(l);
         }
 
 #if ANDROID

--- a/Jypeli/Widgets/InputWindow.cs
+++ b/Jypeli/Widgets/InputWindow.cs
@@ -138,9 +138,10 @@ namespace Jypeli
 
         private void AddListeners()
         {
-            Game.Instance.Keyboard.Listen( Key.Enter, ButtonState.Pressed, Close, null ).InContext( this );
-            Game.Instance.Keyboard.Listen( Key.Escape, ButtonState.Pressed, Cancel, null ).InContext( this );
-            Game.Instance.PhoneBackButton.Listen( Cancel, null ).InContext( this );
+            var l1 = Game.Instance.Keyboard.Listen( Key.Enter, ButtonState.Pressed, Close, null ).InContext( this );
+            var l2 = Game.Instance.Keyboard.Listen( Key.Escape, ButtonState.Pressed, Cancel, null ).InContext( this );
+            var l3 = Game.Instance.PhoneBackButton.Listen( Cancel, null ).InContext( this );
+            associatedListeners.AddItems(l1, l2, l3);
         }
 
 #if WINDOWS_PHONE && TESTING

--- a/Jypeli/Widgets/ListWidget.cs
+++ b/Jypeli/Widgets/ListWidget.cs
@@ -194,8 +194,9 @@ namespace Jypeli
 
         private void AddListeners()
         {
-            Game.Instance.Keyboard.Listen( Key.Up, ButtonState.Pressed, scrollUp, null ).InContext( this );
-            Game.Instance.Keyboard.Listen( Key.Down, ButtonState.Pressed, scrollDown, null ).InContext( this );
+            var l1 = Game.Instance.Keyboard.Listen( Key.Up, ButtonState.Pressed, scrollUp, null ).InContext( this );
+            var l2 = Game.Instance.Keyboard.Listen( Key.Down, ButtonState.Pressed, scrollDown, null ).InContext( this );
+            associatedListeners.AddItems(l1, l2);
         }
 
 #if WINDOWS

--- a/Jypeli/Widgets/MessageWindow.cs
+++ b/Jypeli/Widgets/MessageWindow.cs
@@ -86,15 +86,17 @@ namespace Jypeli
 
         private void AddListeners()
         {
-            Game.Instance.PhoneBackButton.Listen( delegate { Close(); }, null ).InContext( this );
-            Game.Instance.TouchPanel.Listen( ButtonState.Pressed, delegate { Close(); }, null ).InContext( this );
-            Game.Instance.Keyboard.Listen( Key.Enter, ButtonState.Pressed, Close, null ).InContext( this );
-            Game.Instance.Keyboard.Listen( Key.Space, ButtonState.Pressed, Close, null ).InContext( this );
+            var l1 = Game.Instance.PhoneBackButton.Listen( delegate { Close(); }, null ).InContext( this );
+            var l2 = Game.Instance.TouchPanel.Listen( ButtonState.Pressed, delegate { Close(); }, null ).InContext( this );
+            var l3 = Game.Instance.Keyboard.Listen( Key.Enter, ButtonState.Pressed, Close, null ).InContext( this );
+            var l4 = Game.Instance.Keyboard.Listen( Key.Space, ButtonState.Pressed, Close, null ).InContext( this );
+            associatedListeners.AddItems(l1, l2, l3, l4);
 
             foreach ( var controller in Game.Instance.GameControllers )
             {
-                controller.Listen( Button.A, ButtonState.Pressed, Close, null ).InContext( this );
-                controller.Listen( Button.B, ButtonState.Pressed, Close, null ).InContext( this );
+                l1 = controller.Listen( Button.A, ButtonState.Pressed, Close, null ).InContext( this );
+                l2 = controller.Listen( Button.B, ButtonState.Pressed, Close, null ).InContext( this );
+                associatedListeners.AddItems(l1, l2);
             }
         }
     }

--- a/Jypeli/Widgets/MultiSelectWindow.cs
+++ b/Jypeli/Widgets/MultiSelectWindow.cs
@@ -15,8 +15,6 @@ namespace Jypeli
         private int _defaultCancel = 0;
         private List<Listener> _defaultListeners = new List<Listener>(4);
 
-        private List<Listener> _listeners = new List<Listener>(32);
-
         private int _selectedIndex = -1;
         private Color _selectedColor = Color.Black;
         private Color _selectionColor = Color.Cyan;
@@ -180,10 +178,7 @@ namespace Jypeli
         private void DeinitOnRemove()
         {
             _defaultListeners.ForEach(l => l.Destroy());
-            _listeners.ForEach(l => l.Destroy());
-
             _defaultListeners.Clear();
-            _listeners.Clear();
         }
 
         private void SelectButton( int p )
@@ -261,7 +256,7 @@ namespace Jypeli
             for ( int i = 0; i < Math.Min( Buttons.Length, keys.Length ); i++ )
             {
                 var l = Keyboard.Listen(keys[i], ButtonState.Pressed, SelectButton, null, i).InContext(this);
-                _listeners.Add(l);
+                associatedListeners.Add(l);
             }
 
             Action selectPrev = delegate { SelectButton( _selectedIndex > 0 ? _selectedIndex - 1 : Buttons.Length - 1 ); };
@@ -271,14 +266,14 @@ namespace Jypeli
             var l1 = Keyboard.Listen( Key.Up, ButtonState.Pressed, selectPrev, null ).InContext( this );
             var l2 = Keyboard.Listen( Key.Down, ButtonState.Pressed, selectNext, null ).InContext( this );
             var l3 = Keyboard.Listen( Key.Enter, ButtonState.Pressed, confirmSelect, null ).InContext( this );
-            _listeners.AddItems(l1, l2, l3);
+            associatedListeners.AddItems(l1, l2, l3);
 
             foreach ( var controller in Game.Instance.GameControllers )
             {
                 l1 = controller.Listen( Button.DPadUp, ButtonState.Pressed, selectPrev, null ).InContext( this );
                 l2 = controller.Listen( Button.DPadDown, ButtonState.Pressed, selectNext, null ).InContext( this );
                 l3 = controller.Listen( Button.A, ButtonState.Pressed, confirmSelect, null ).InContext( this );
-                _listeners.AddItems(l1, l2, l3);
+                associatedListeners.AddItems(l1, l2, l3);
             }
         }
 

--- a/Jypeli/Widgets/PushButton.cs
+++ b/Jypeli/Widgets/PushButton.cs
@@ -28,6 +28,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 
 namespace Jypeli
@@ -234,20 +235,22 @@ namespace Jypeli
 
         private void InitializeControls()
         {
-            Game.Mouse.ListenOn( this, MouseButton.Left, ButtonState.Pressed, SetState, null, State.LeftPressed ).InContext( this );
-            Game.Mouse.ListenOn( this, MouseButton.Left, ButtonState.Released, Release, null ).InContext( this );
-            Game.Mouse.Listen( MouseButton.Left, ButtonState.Released, Release, null ).InContext( this );
+            var l1 = Game.Mouse.ListenOn( this, MouseButton.Left, ButtonState.Pressed, SetState, null, State.LeftPressed ).InContext( this );
+            var l2 = Game.Mouse.ListenOn( this, MouseButton.Left, ButtonState.Released, Release, null ).InContext( this );
+            var l3 = Game.Mouse.Listen( MouseButton.Left, ButtonState.Released, Release, null ).InContext( this );
 
-            Game.Mouse.ListenOn( this, MouseButton.Right, ButtonState.Pressed, SetState, null, State.RightPressed ).InContext( this );
-            Game.Mouse.ListenOn( this, MouseButton.Right, ButtonState.Released, Release, null ).InContext( this );
-            Game.Mouse.Listen( MouseButton.Right, ButtonState.Released, Release, null ).InContext( this );
+            var l4 = Game.Mouse.ListenOn( this, MouseButton.Right, ButtonState.Pressed, SetState, null, State.RightPressed ).InContext( this );
+            var l5 = Game.Mouse.ListenOn( this, MouseButton.Right, ButtonState.Released, Release, null ).InContext( this );
+            var l6 = Game.Mouse.Listen( MouseButton.Right, ButtonState.Released, Release, null ).InContext( this );
 
-            Game.Mouse.ListenMovement( 1.0, CheckHover, null ).InContext( this );
+            var l7 = Game.Mouse.ListenMovement( 1.0, CheckHover, null ).InContext( this );
 
-            Game.Instance.TouchPanel.Listen( ButtonState.Down, TouchHover, null ).InContext( this );
-            Game.Instance.TouchPanel.ListenOn( this, ButtonState.Released, TouchRelease, null ).InContext( this );
-            Game.Instance.TouchPanel.Listen( ButtonState.Released, TouchRelease, null ).InContext( this );
-            Game.Instance.TouchPanel.ListenOn(  this, ButtonState.Released, TouchClick, null ).InContext( this );
+            var l8 = Game.Instance.TouchPanel.Listen( ButtonState.Down, TouchHover, null ).InContext( this );
+            var l9 = Game.Instance.TouchPanel.ListenOn( this, ButtonState.Released, TouchRelease, null ).InContext( this );
+            var l10 = Game.Instance.TouchPanel.Listen( ButtonState.Released, TouchRelease, null ).InContext( this );
+            var l11 = Game.Instance.TouchPanel.ListenOn(  this, ButtonState.Released, TouchClick, null ).InContext( this );
+
+            associatedListeners.AddItems(l1, l2, l3, l4, l5, l6, l7, l8, l9, l10, l11);
         }
 
         private void InitializeShape()
@@ -341,18 +344,20 @@ namespace Jypeli
         /// Lisää pikanäppäimen napille.
         /// </summary>
         /// <param name="key">Näppäin</param>
-        public void AddShortcut( Key key )
+        public Listener AddShortcut( Key key )
         {
-            Jypeli.Game.Instance.Keyboard.Listen( key, ButtonState.Pressed, Click, null ).InContext( this );
+            return Jypeli.Game.Instance.Keyboard.Listen( key, ButtonState.Pressed, Click, null ).InContext( this );
         }
 
         /// <summary>
         /// Lisää pikanäppäimen kaikille ohjaimille.
         /// </summary>
         /// <param name="button">Näppäin</param>
-        public void AddShortcut( Button button )
+        public List<Listener> AddShortcut( Button button )
         {
-            Game.Instance.GameControllers.ForEach( c => AddShortcut( c, button ) );
+            var listeners = new List<Listener>(Game.GameControllers.Count);
+            Game.Instance.GameControllers.ForEach( c => listeners.Add(AddShortcut( c, button )) );
+            return listeners;
         }
 
         /// <summary>
@@ -360,9 +365,9 @@ namespace Jypeli
         /// </summary>
         /// <param name="player">Peliohjaimen indeksi 0-3</param>
         /// <param name="button">Näppäin</param>
-        public void AddShortcut( int player, Button button )
+        public Listener AddShortcut( int player, Button button )
         {
-            AddShortcut( Game.Instance.GameControllers[player], button );
+            return AddShortcut( Game.Instance.GameControllers[player], button );
         }
 
         /// <summary>
@@ -370,9 +375,9 @@ namespace Jypeli
         /// </summary>
         /// <param name="controller">Peliohjain</param>
         /// <param name="button">Näppäin</param>
-        public void AddShortcut( GamePad controller, Button button )
+        public Listener AddShortcut( GamePad controller, Button button )
         {
-            controller.Listen( button, ButtonState.Pressed, Click, null ).InContext( this );
+            return controller.Listen( button, ButtonState.Pressed, Click, null ).InContext( this );
         }
 
         private void Release()

--- a/Jypeli/Widgets/Slider.cs
+++ b/Jypeli/Widgets/Slider.cs
@@ -79,7 +79,7 @@ namespace Jypeli.Widgets
             Knob.Color = Color.DarkGray;
             Add(Knob);
 
-            Game.AssertInitialized(InitializeControls);
+            AddedToGame += InitializeControls;
         }
 
         /// <summary>
@@ -97,13 +97,15 @@ namespace Jypeli.Widgets
 
         private void InitializeControls()
         {
-            Game.Mouse.ListenOn(this, MouseButton.Left, ButtonState.Pressed, MousePress, null).InContext(this);
-            Game.Mouse.Listen(MouseButton.Left, ButtonState.Released, MouseRelease, null).InContext(this);
-            Game.Mouse.ListenMovement(1.0, MouseMove, null).InContext(this);
+            var l1 = Game.Mouse.ListenOn(this, MouseButton.Left, ButtonState.Pressed, MousePress, null).InContext(this);
+            var l2 = Game.Mouse.Listen(MouseButton.Left, ButtonState.Released, MouseRelease, null).InContext(this);
+            var l3 = Game.Mouse.ListenMovement(1.0, MouseMove, null).InContext(this);
 
-            Game.TouchPanel.ListenOn(this, ButtonState.Pressed, TouchPress, null).InContext(this);
-            Game.TouchPanel.Listen(ButtonState.Released, TouchRelease, null).InContext(this);
-            Game.TouchPanel.Listen(ButtonState.Down, TouchMove, null).InContext(this);
+            var l4 = Game.TouchPanel.ListenOn(this, ButtonState.Pressed, TouchPress, null).InContext(this);
+            var l5 = Game.TouchPanel.Listen(ButtonState.Released, TouchRelease, null).InContext(this);
+            var l6 = Game.TouchPanel.Listen(ButtonState.Down, TouchMove, null).InContext(this);
+
+            associatedListeners.AddItems(l1, l2, l3, l4, l5, l6);
         }
 
         public override void BindTo(Meter meter)

--- a/Jypeli/Widgets/SplashScreen.cs
+++ b/Jypeli/Widgets/SplashScreen.cs
@@ -167,24 +167,32 @@ namespace Jypeli.Widgets
 
             StartLabel.SizeMode = TextSizeMode.Wrapped;
 
-            Game.Keyboard.Listen(Key.Enter, ButtonState.Pressed, BeginLoad, null, StartLabel).InContext(this);
-            Game.Keyboard.Listen(Key.Escape, ButtonState.Pressed, Game.Instance.Exit, null).InContext(this); ;
-            Game.Mouse.Listen(MouseButton.Left, ButtonState.Down, BeginLoad, null, StartLabel).InContext(this);
-
-            for (int i = 0; i < Game.GameControllers.Count; i++)
-            {
-                Game.GameControllers[i].Listen(Button.A, ButtonState.Pressed, BeginLoad, null, StartLabel).InContext(this);
-                Game.GameControllers[i].Listen(Button.B, ButtonState.Pressed, Game.Instance.Exit, null).InContext(this);
-            }
-
-            Game.TouchPanel.ListenOn(StartLabel, ButtonState.Pressed, delegate { BeginLoad(StartLabel); }, null).InContext(this);
-            Game.PhoneBackButton.Listen(Game.Instance.Exit, null).InContext(this);
+            AddedToGame += AddControls;
 
             Add(NameLabel);
             Add(CopyrightLabel);
             Add(AuthorsLabel);
             Add(TextBody);
             Add(StartLabel);
+        }
+
+        private void AddControls()
+        {
+            var l1 = Game.Keyboard.Listen(Key.Enter, ButtonState.Pressed, BeginLoad, null, StartLabel).InContext(this);
+            var l2 = Game.Keyboard.Listen(Key.Escape, ButtonState.Pressed, Game.Instance.Exit, null).InContext(this); ;
+            var l3 = Game.Mouse.Listen(MouseButton.Left, ButtonState.Down, BeginLoad, null, StartLabel).InContext(this);
+            associatedListeners.AddItems(l1, l2, l3);
+
+            for (int i = 0; i < Game.GameControllers.Count; i++)
+            {
+                l1 = Game.GameControllers[i].Listen(Button.A, ButtonState.Pressed, BeginLoad, null, StartLabel).InContext(this);
+                l2 = Game.GameControllers[i].Listen(Button.B, ButtonState.Pressed, Game.Instance.Exit, null).InContext(this);
+                associatedListeners.AddItems(l1, l2);
+            }
+
+            l1 = Game.TouchPanel.ListenOn(StartLabel, ButtonState.Pressed, delegate { BeginLoad(StartLabel); }, null).InContext(this);
+            l2 = Game.PhoneBackButton.Listen(Game.Instance.Exit, null).InContext(this);
+            associatedListeners.AddItems(l1, l2);
         }
 
         private void BeginLoad(Label aloitusohje)

--- a/Jypeli/Widgets/StringListWindow.cs
+++ b/Jypeli/Widgets/StringListWindow.cs
@@ -49,7 +49,7 @@ namespace Jypeli
         public StringListWindow( string question )
             : base( question )
         {
-            Game.AssertInitialized( AddControls );
+            AddedToGame += AddControls;
         }
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace Jypeli
         public StringListWindow( double width, double height, string question )
             : base( width, height, question )
         {
-            Game.AssertInitialized( AddControls );
+            AddedToGame += AddControls;
         }
 
         protected override StringListWidget CreateQueryWidget()
@@ -71,7 +71,8 @@ namespace Jypeli
 
         void AddControls()
         {
-            Jypeli.Game.Instance.PhoneBackButton.Listen( Close, null ).InContext( this );
+            var l = Jypeli.Game.Instance.PhoneBackButton.Listen( Close, null ).InContext( this );
+            associatedListeners.Add(l);
         }
     }
 }

--- a/Jypeli/Widgets/Window.cs
+++ b/Jypeli/Widgets/Window.cs
@@ -167,9 +167,10 @@ namespace Jypeli
 
         void AddControls()
         {
-            Game.Mouse.ListenOn( this, MouseButton.Left, ButtonState.Pressed, StartMoveWindow, null ).InContext( this );
-            Game.Mouse.Listen( MouseButton.Left, ButtonState.Down, MoveWindow, null ).InContext( this );
-            Game.Mouse.ListenOn( this, MouseButton.Left, ButtonState.Released, EndMoveWindow, null ).InContext( this );
+            var l1 = Game.Mouse.ListenOn( this, MouseButton.Left, ButtonState.Pressed, StartMoveWindow, null ).InContext( this );
+            var l2 = Game.Mouse.Listen( MouseButton.Left, ButtonState.Down, MoveWindow, null ).InContext( this );
+            var l3 = Game.Mouse.ListenOn( this, MouseButton.Left, ButtonState.Released, EndMoveWindow, null ).InContext( this );
+            associatedListeners.AddItems(l1, l2, l3);
         }
 
         void StartMoveWindow()

--- a/Jypeli/Widgets/YesNoWindow.cs
+++ b/Jypeli/Widgets/YesNoWindow.cs
@@ -72,11 +72,19 @@ namespace Jypeli
             AddItemHandler( 1, OnNo );
 
             Buttons[0].Color = Color.Green;
-            Buttons[0].AddShortcut( Button.A );
-
             Buttons[1].Color = Color.DarkRed;
-            Buttons[1].AddShortcut( Button.B );
+
             DefaultCancel = 1;
+
+            AddedToGame += AddControls;
+        }
+
+        private void AddControls()
+        {
+            var l1 = Buttons[0].AddShortcut(Button.A);
+            var l2 = Buttons[1].AddShortcut(Button.B);
+            associatedListeners.AddRange(l1);
+            associatedListeners.AddRange(l2);
         }
     }
 }


### PR DESCRIPTION
Fixed the rest of the listener leaks in Widgets. No functionality has been changed.

Noticed that Widget already had an unused internal member List named 'associatedListeners'. It is now used for keeping track of listeners to be removed.

It is worth noting that associatedListeners is still internal, so if a user decides to inherit Widget and associate listeners to it, they will have to take care of the cleanup themselves. On the other hand, though, they will not be able to mess up the default functionality of the Widgets either.