### PR TITLE
Improve window moving behaviour

### DIFF
--- a/Jypeli/GameObjects/Widget/Control.cs
+++ b/Jypeli/GameObjects/Widget/Control.cs
@@ -21,6 +21,29 @@ namespace Jypeli
         /// </summary>
         public bool IsModal { get; set; }
 
+        public bool CapturesMouse { get; protected set; }
+        public bool IsCapturingMouse
+        {
+            get
+            {
+                // A widget IsCapturingMouse if either:
+                //     it CapturesMouse and is under the cursor
+                // or:
+                //     one of its children IsCapturingMouse.
+
+                if (CapturesMouse && Game.Mouse.IsCursorOn(this))
+                    return true;
+
+                foreach (var o in Objects)
+                {
+                    if (o is Widget w && w.IsCapturingMouse)
+                        return true;
+                }
+
+                return false;
+            }
+        }
+
         public void InitControl()
         {
             if ( ControlContext == null || ControlContext.IsDestroyed )

--- a/Jypeli/Widgets/PushButton.cs
+++ b/Jypeli/Widgets/PushButton.cs
@@ -200,6 +200,7 @@ namespace Jypeli
             InitializeShape();
             Color = new Color( 70, 130, 180, 230 );
             TextColor = new Color( 250, 250, 250, 240 );
+            CapturesMouse = true;
             AddedToGame += InitializeControls;
         }
 

--- a/Jypeli/Widgets/Slider.cs
+++ b/Jypeli/Widgets/Slider.cs
@@ -71,6 +71,7 @@ namespace Jypeli.Widgets
             : base(width, height)
         {
             Color = Color.Transparent;
+            CapturesMouse = true;
 
             Track = new Widget(width, height / 3);
             Add(Track);

--- a/Jypeli/Widgets/Slider.cs
+++ b/Jypeli/Widgets/Slider.cs
@@ -129,7 +129,7 @@ namespace Jypeli.Widgets
 
         private void GenMove(Vector newPos)
         {
-            Vector u = Vector.FromLengthAndAngle(1, this.Angle);
+            Vector u = Vector.FromLengthAndAngle(1, this.AbsoluteAngle);
             double newVal = newPos.ScalarProjection(u);
 
             if (newVal < Track.Left) Knob.X = Track.Left;
@@ -151,7 +151,7 @@ namespace Jypeli.Widgets
             Knob.Color = pressedDown || Game.Mouse.IsCursorOn(this) ? _activeColor : _inactiveColor;
 
             if (pressedDown)
-                GenMove(Game.Mouse.PositionOnScreen - this.Position);
+                GenMove(Game.Mouse.PositionOnScreen - this.AbsolutePosition);
         }
 
         private void MouseRelease()
@@ -172,7 +172,7 @@ namespace Jypeli.Widgets
         private void TouchMove(Touch touch)
         {
             if (touchObject == touch)
-                GenMove(touch.PositionOnScreen - this.Position);
+                GenMove(touch.PositionOnScreen - this.AbsolutePosition);
         }
 
         private void TouchRelease(Touch touch)

--- a/Jypeli/Widgets/Window.cs
+++ b/Jypeli/Widgets/Window.cs
@@ -176,6 +176,12 @@ namespace Jypeli
         void StartMoveWindow()
         {
             if ( Game == null ) return;
+            foreach (var obj in Objects)
+            {
+                if (obj is Widget w && w.IsCapturingMouse)
+                    return;
+            }
+
             movementCenter = this.Position - Game.Mouse.PositionOnScreen;
             moving = true;
         }


### PR DESCRIPTION
Now it is possible to prevent windows from being dragged if widgets inside them need to capture mouse events.

With the current selection of Widgets, this allows Sliders to be used inside windows and PushButton activation to be cancelled by moving the cursor off the button before releasing the left mouse button. These operations were previously impossible as the window would just follow the cursor.

Also fixed a minor bug in Slider where relative transformations were used instead of absolute.