### PR TITLE
Fix headless mode regressions

### DIFF
--- a/Jypeli/Game/Game.cs
+++ b/Jypeli/Game/Game.cs
@@ -420,14 +420,14 @@ namespace Jypeli
                     }
             }
 
-            FrameCounter++;
-
             if (TotalFramesToRun != 0 && FrameCounter == TotalFramesToRun)
             {
                 OnExiting(this, EventArgs.Empty);
                 //UnloadContent();
                 Exit();
             }
+
+            FrameCounter++;
         }
 
         /// <summary>

--- a/Jypeli/Game/Game.cs
+++ b/Jypeli/Game/Game.cs
@@ -278,6 +278,12 @@ namespace Jypeli
 
         private void InitAudio()
         {
+            if (Headless)
+            {
+                DisableAudio();
+                return;
+            }
+
             try
             {
                 Audio.OpenAL.OpenAL.Init();

--- a/Jypeli/Game/Game.cs
+++ b/Jypeli/Game/Game.cs
@@ -85,7 +85,7 @@ namespace Jypeli
         /// <summary>
         /// Kirjoitetaanko kuvatiedosto standarditulosteeseen jos <see cref="SaveOutput"/> on päällä.
         /// </summary>
-        public bool SaveOutputToConsole { get; private set; }
+        public bool SaveOutputToConsole { get; } = CommandLineOptions.SaveToStdout ?? false;
 
         /// <summary>
         /// Ajetaanko peli ilman ääntä (esim. TIMissä)
@@ -140,8 +140,6 @@ namespace Jypeli
 
         private readonly Lazy<Stream> standardOutStream = new Lazy<Stream>(Console.OpenStandardOutput);
         
-
-
         /// <summary>
         /// Onko peli sulkeutumassa tämän päivityksen jölkeen.
         /// </summary>
@@ -176,12 +174,10 @@ namespace Jypeli
         public void Run(bool headless = false, bool save = false, int frames = 0, int skip = 1)
         {
             if (frames < 0) throw new ArgumentException("n must be greater than 0!");
-            TotalFramesToRun = frames;
-            SaveOutput = save;
-            Headless = headless;
-            FramesToSkip = skip;
-
-            ApplyCMDArgs();
+            TotalFramesToRun = CommandLineOptions.FramesToRun ?? frames;
+            SaveOutput = CommandLineOptions.Save ?? save;
+            Headless = CommandLineOptions.Headless ?? headless;
+            FramesToSkip = CommandLineOptions.SkipFrames ?? skip;
 
             if (SaveOutput && !Directory.Exists("Output"))
             {
@@ -189,46 +185,6 @@ namespace Jypeli
             }
 
             Window.Run();
-        }
-
-        private void ApplyCMDArgs()
-        {
-            string[] args = Environment.GetCommandLineArgs();
-            if (args.Contains("--save"))
-            {
-                if (bool.TryParse(args[Array.IndexOf(args, "--save") + 1], out bool save))
-                    SaveOutput = save;
-                else
-                    throw new ArgumentException("Invalid value for --save");
-            }
-            if (args.Contains("--framesToRun"))
-            {
-                if (int.TryParse(args[Array.IndexOf(args, "--framesToRun") + 1], out int frames))
-                    TotalFramesToRun = frames;
-                else
-                    throw new ArgumentException("Invalid value for --framesToRun");
-            }
-            if (args.Contains("--headless"))
-            {
-                if (bool.TryParse(args[Array.IndexOf(args, "--headless") + 1], out bool headless))
-                    Headless = headless;
-                else
-                    throw new ArgumentException("Invalid value for --headless");
-            }
-            if (args.Contains("--skipFrames"))
-            {
-                if (int.TryParse(args[Array.IndexOf(args, "--skipFrames") + 1], out int skip))
-                    FramesToSkip = skip;
-                else
-                    throw new ArgumentException("Invalid value for --skipFrames");
-            }
-            if (args.Contains("--saveToStdout"))
-            {
-                if (bool.TryParse(args[Array.IndexOf(args, "--saveToStdout") + 1], out bool saveToStdout))
-                    SaveOutputToConsole = saveToStdout;
-                else
-                    throw new ArgumentException("Invalid value for --saveToStdout");
-            }
         }
 
         internal static void DisableAudio()
@@ -278,12 +234,6 @@ namespace Jypeli
 
         private void InitAudio()
         {
-            if (Headless)
-            {
-                DisableAudio();
-                return;
-            }
-
             try
             {
                 Audio.OpenAL.OpenAL.Init();

--- a/Jypeli/Helpers/CommandLineOptions.cs
+++ b/Jypeli/Helpers/CommandLineOptions.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Linq;
+
+namespace Jypeli
+{
+    internal static class CommandLineOptions
+    {
+        static CommandLineOptions()
+        {
+            string[] args = Environment.GetCommandLineArgs();
+            Save = Parse<bool>(args, "save", bool.TryParse);
+            FramesToRun = Parse<int>(args, "framesToRun", int.TryParse);
+            Headless = Parse<bool>(args, "headless", bool.TryParse);
+            SkipFrames = Parse<int>(args, "skipFrames", int.TryParse);
+            SaveToStdout = Parse<bool>(args, "saveToStdout", bool.TryParse);
+        }
+
+        public static bool? Save { get; }
+        public static int? FramesToRun { get; }
+        public static bool? Headless { get; }
+        public static int? SkipFrames { get; }
+        public static bool? SaveToStdout { get; }
+
+        private static T? Parse<T>(string[] args, string value, TryParseDelegate<T> parser) where T : struct
+        {
+            string argName = $"--{value}";
+            if (!args.Contains(argName))
+                return null;
+            if (parser(args[Array.IndexOf(args, argName) + 1], out T result))
+                return result;
+            throw new ArgumentException("Invalid value for --save");
+        }
+
+        private delegate bool TryParseDelegate<T>(string value, out T result);
+    }
+}


### PR DESCRIPTION
Korjaa joitakin #23:n regressioita headless-tilassa sekä refaktoroi hieman konsoliargumenttien parsintaa toimimaan uuden koodin suoritusjärestyksen kanssa.

Olennaiset muutokset:

* Korjaa pelin kaatumisen, jos OpenAL ei löydä mitään äänilaitteita
* Palauttaa takaisin commitin aeaf376c3cc0e093c237e36f902fbcdae59acaf5 korjauksen argumentille `--framesToRun`
* Palauttaa takaisin argumentin `--headless` toiminnan, eli silloin ei yritetä ladata äänilaitteitta
* Pieni refaktorointi argumenttien parsinnalle: siirretty parsinta omaan paikkaan, koska nykyään argumentit tarvitaan aikaisemmin (esim. äänilaitteen lataaminen tehdään nyt ennen `Run`ia toisin kuin MonoGamen kanssa).

En ruvennut hienostelemaan argumenttien parsinnan kanssa, eli sen toteutus on pitkälti sama kuin ennenkin.  
En myöskään ruvennut säätämään `Run(bool headless = false, bool save = false, int frames = 0, int skip = 1)`:n argumenttien kanssa, koska se rikkoisi binääriyhteensopivuuden (jos se on nyt Jypelille tärkeä säilyttää). Muuten TIMin kannalta tuota Run-versiota ei enää tarvittaisi, koska kaikki headless-tilaan liittyvät asetukset passitetaan suoraan komentoriviargumenttien kautta.

Testattu lokaalisti testipelillä sekä lokaalilla TIM-asennuksella.