### PR TITLE
Bump Silk.NET to 2.16.0

### DIFF
--- a/Jypeli/Jypeli.csproj
+++ b/Jypeli/Jypeli.csproj
@@ -133,14 +133,14 @@
 
 	<ItemGroup>
 		<PackageReference Include="FontStashSharp" Version="1.0.4" />
-		<PackageReference Include="Silk.NET.Input" Version="2.15.0" />
-		<PackageReference Include="Silk.NET.OpenGL" Version="2.15.0" />
-		<PackageReference Include="Silk.NET.Windowing" Version="2.15.0" />
+		<PackageReference Include="Silk.NET.Input" Version="2.16.0" />
+		<PackageReference Include="Silk.NET.OpenGL" Version="2.16.0" />
+		<PackageReference Include="Silk.NET.Windowing" Version="2.16.0" />
 		<PackageReference Include="SixLabors.ImageSharp" Version="2.1.0" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-		<PackageReference Include="Silk.NET.OpenAL" Version="2.15.0" />
+		<PackageReference Include="Silk.NET.OpenAL" Version="2.16.0" />
 		<PackageReference Include="Silk.NET.OpenAL.Soft.Native" Version="1.21.1.1" />
 	</ItemGroup>
 	


### PR DESCRIPTION
Päivittää Silk.NET -kirjaston uusimpaan versioon. Uusin versio korjaa grafiikkakirjastojen resolvetusta, katso https://github.com/TIM-JYU/TIM/issues/3153#issuecomment-1231404531

Toimivuus testattu projektissa olevilla testipeleillä Linuxilla (RHEL 8) sekä Windowsilla (Win11, versio 10.0.22000).