### PR TITLE
Fix NRE when disposing of SoundEffect in headless mode

### DIFF
--- a/Jypeli/Audio/OpenAL/OpenAL.cs
+++ b/Jypeli/Audio/OpenAL/OpenAL.cs
@@ -262,7 +262,7 @@ namespace Jypeli.Audio.OpenAL
 
         public void Destroy(uint handle)
         {
-            al.DeleteSource(handle);
+            al?.DeleteSource(handle);
         }
 
         public uint Duplicate(uint from)


### PR DESCRIPTION
Korjaa NRE:n, kun GC tuhoaa SoundEffect-objektin headless-tilassa. Katso https://github.com/TIM-JYU/TIM/issues/3179