### PR TITLE
Add basic symbol replacements to templates

### DIFF
--- a/Projektimallit/Jypeli.Templates/Jypeli.Templates.csproj
+++ b/Projektimallit/Jypeli.Templates/Jypeli.Templates.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <BaseOutputPath>..\build</BaseOutputPath>
     <PackageType>Template</PackageType>
-    <Version>1.7</Version>
+    <Version>1.8</Version>
 
     <Title>Jypeli projektimallit</Title>
     <Description>Jypelin projektimallit Visual Studiolle</Description>

--- a/Projektimallit/Jypeli.Templates/content/AndroidFysiikkapeli/.template.config/template.json
+++ b/Projektimallit/Jypeli.Templates/content/AndroidFysiikkapeli/.template.config/template.json
@@ -11,18 +11,46 @@
             "type": "parameter",
             "description": "Käytettävä .NET-versio.",
             "datatype": "choice",
-            "defaultValue": "net7.0-android",
-            "replaces": "net7.0-android",
+            "defaultValue": "net7.0",
+            "replaces": "net7.0",
             "choices": [
                 {
-                    "choice": "net7.0-android",
+                    "choice": "net7.0",
                     "description": "Käytä .NET 7"
                 },
                 {
-                    "choice": "net6.0-android",
+                    "choice": "net6.0",
                     "description": "Käytä .NET 6"
                 }
             ]
+        },
+        "version": {
+            "type": "generated",
+            "generator": "now",
+            "parameters": {
+                "format": "dd.MM.yyyy"
+            },
+            "replaces": "Päivämäärä"
+        },
+        "WindowsUserName": {
+            "type": "bind",
+            "binding": "env:USERNAME",
+            "defaultValue": "Omanimi"
+        },
+        "UnixUserName": {
+            "type": "bind",
+            "binding": "env:USER",
+            "defaultValue": "Omanimi"
+        },
+        "author": {
+            "type": "generated",
+            "generator": "coalesce",
+            "parameters": {
+                "sourceVariableName": "WindowsUserName",
+                "fallbackVariableName": "UnixUserName",
+                "defaultValue": "Omanimi"
+            },
+            "replaces": "Omanimi"
         }
     },
     "tags": {

--- a/Projektimallit/Jypeli.Templates/content/AndroidFysiikkapeli/.template.config/template.json
+++ b/Projektimallit/Jypeli.Templates/content/AndroidFysiikkapeli/.template.config/template.json
@@ -1,12 +1,30 @@
 {
+    "$schema": "http://json.schemastore.org/template",
     "author": "University of Jyväskylä",
-    "classifications": [
-        "Jypeli"
-    ],
+    "classifications": ["Jypeli"],
     "name": "Android Fysiikkapeli",
     "identity": "Jypeli.AndroidFysiikkapeli",
     "groupIdentity": "Jypeli.AndroidFysiikkapeli",
     "shortName": "AndroidFysiikkapeli",
+    "symbols": {
+        "framework": {
+            "type": "parameter",
+            "description": "Käytettävä .NET-versio.",
+            "datatype": "choice",
+            "defaultValue": "net7.0-android",
+            "replaces": "net7.0-android",
+            "choices": [
+                {
+                    "choice": "net7.0-android",
+                    "description": "Käytä .NET 7"
+                },
+                {
+                    "choice": "net6.0-android",
+                    "description": "Käytä .NET 6"
+                }
+            ]
+        }
+    },
     "tags": {
         "language": "C#",
         "type": "project"
@@ -17,6 +35,6 @@
         }
     ],
     "sourceName": "AndroidFysiikkapeli",
-    "preferNameDirectory": "true",
+    "preferNameDirectory": true,
     "description": "Fysiikkapelipohja Androidille."
 }

--- a/Projektimallit/Jypeli.Templates/content/AndroidFysiikkapeli/AndroidFysiikkapeli.cs
+++ b/Projektimallit/Jypeli.Templates/content/AndroidFysiikkapeli/AndroidFysiikkapeli.cs
@@ -7,6 +7,11 @@ using Jypeli.Widgets;
 
 namespace AndroidFysiikkapeli;
 
+/// @author Omanimi
+/// @version Päivämäärä
+/// <summary>
+/// 
+/// </summary>
 public class AndroidFysiikkapeli : PhysicsGame
 {
     public override void Begin()

--- a/Projektimallit/Jypeli.Templates/content/ConsoleMain/.template.config/template.json
+++ b/Projektimallit/Jypeli.Templates/content/ConsoleMain/.template.config/template.json
@@ -1,12 +1,58 @@
 {
+    "$schema": "http://json.schemastore.org/template",
     "author": "University of Jyväskylä",
-    "classifications": [
-        "Jypeli"
-    ],
+    "classifications": ["Jypeli"],
     "name": "ConsoleMain",
     "identity": "Jypeli.ConsoleMain",
     "groupIdentity": "Jypeli.ConsoleMain",
     "shortName": "ConsoleMain",
+    "symbols": {
+        "framework": {
+            "type": "parameter",
+            "description": "Käytettävä .NET-versio.",
+            "datatype": "choice",
+            "defaultValue": "net7.0",
+            "replaces": "net7.0",
+            "choices": [
+                {
+                    "choice": "net7.0",
+                    "description": "Käytä .NET 7"
+                },
+                {
+                    "choice": "net6.0",
+                    "description": "Käytä .NET 6"
+                }
+            ]
+        },
+        "version": {
+            "type": "generated",
+            "generator": "now",
+            "parameters": {
+                "format": "dd.MM.yyyy"
+            },
+            "replaces": "Päivämäärä"
+        },
+        "WindowsUserName": {
+            "type": "bind",
+            "binding": "env:USERNAME",
+            "defaultValue": "Omanimi"
+        },
+        "UnixUserName": {
+            "type": "bind",
+            "binding": "env:USER",
+            "defaultValue": "Omanimi"
+        },
+        "author": {
+            "type": "generated",
+            "generator": "coalesce",
+            "parameters": {
+                "sourceVariableName": "WindowsUserName",
+                "fallbackVariableName": "UnixUserName",
+                "defaultValue": "Omanimi"
+            },
+            "replaces": "Omanimi"
+        }
+    },
     "tags": {
         "language": "C#",
         "type": "project"
@@ -17,6 +63,6 @@
         }
     ],
     "sourceName": "ConsoleMain",
-    "preferNameDirectory": "true",
+    "preferNameDirectory": true,
     "description": "Tyhjä Console Main-projekti, jossa kommenttien paikka valmiina."
 }

--- a/Projektimallit/Jypeli.Templates/content/Fysiikkapeli/.template.config/template.json
+++ b/Projektimallit/Jypeli.Templates/content/Fysiikkapeli/.template.config/template.json
@@ -22,6 +22,34 @@
                     "description": "Käytä .NET 6"
                 }
             ]
+        },
+        "version": {
+            "type": "generated",
+            "generator": "now",
+            "parameters": {
+                "format": "dd.MM.yyyy"
+            },
+            "replaces": "Päivämäärä"
+        },
+        "WindowsUserName": {
+            "type": "bind",
+            "binding": "env:USERNAME",
+            "defaultValue": "Omanimi"
+        },
+        "UnixUserName": {
+            "type": "bind",
+            "binding": "env:USER",
+            "defaultValue": "Omanimi"
+        },
+        "author": {
+            "type": "generated",
+            "generator": "coalesce",
+            "parameters": {
+                "sourceVariableName": "WindowsUserName",
+                "fallbackVariableName": "UnixUserName",
+                "defaultValue": "Omanimi"
+            },
+            "replaces": "Omanimi"
         }
     },
     "shortName": "Fysiikkapeli",

--- a/Projektimallit/Jypeli.Templates/content/Fysiikkapeli/.template.config/template.json
+++ b/Projektimallit/Jypeli.Templates/content/Fysiikkapeli/.template.config/template.json
@@ -1,11 +1,29 @@
 {
+    "$schema": "http://json.schemastore.org/template",
     "author": "University of Jyväskylä",
-    "classifications": [
-        "Jypeli"
-    ],
+    "classifications": ["Jypeli"],
     "name": "Fysiikkapeli",
     "identity": "Jypeli.Fysiikkapeli",
     "groupIdentity": "Jypeli.Fysiikkapeli",
+    "symbols": {
+        "framework": {
+            "type": "parameter",
+            "description": "Käytettävä .NET-versio.",
+            "datatype": "choice",
+            "defaultValue": "net7.0",
+            "replaces": "net7.0",
+            "choices": [
+                {
+                    "choice": "net7.0",
+                    "description": "Käytä .NET 7"
+                },
+                {
+                    "choice": "net6.0",
+                    "description": "Käytä .NET 6"
+                }
+            ]
+        }
+    },
     "shortName": "Fysiikkapeli",
     "tags": {
         "language": "C#",
@@ -17,6 +35,6 @@
         }
     ],
     "sourceName": "Fysiikkapeli",
-    "preferNameDirectory": "true",
+    "preferNameDirectory": true,
     "description": "Fysiikkapeli joka käyttää FarseerPhysics-fysiikkamoottoria."
 }

--- a/Projektimallit/Jypeli.Templates/content/Fysiikkapeli/Fysiikkapeli.cs
+++ b/Projektimallit/Jypeli.Templates/content/Fysiikkapeli/Fysiikkapeli.cs
@@ -7,6 +7,11 @@ using Jypeli.Widgets;
 
 namespace Fysiikkapeli;
 
+/// @author Omanimi
+/// @version Päivämäärä
+/// <summary>
+/// 
+/// </summary>
 public class Fysiikkapeli : PhysicsGame
 {
     public override void Begin()

--- a/Projektimallit/Jypeli.Templates/content/Peruspeli/.template.config/template.json
+++ b/Projektimallit/Jypeli.Templates/content/Peruspeli/.template.config/template.json
@@ -23,6 +23,34 @@
                     "description": "Käytä .NET 6"
                 }
             ]
+        },
+        "version": {
+            "type": "generated",
+            "generator": "now",
+            "parameters": {
+                "format": "dd.MM.yyyy"
+            },
+            "replaces": "Päivämäärä"
+        },
+        "WindowsUserName": {
+            "type": "bind",
+            "binding": "env:USERNAME",
+            "defaultValue": "Omanimi"
+        },
+        "UnixUserName": {
+            "type": "bind",
+            "binding": "env:USER",
+            "defaultValue": "Omanimi"
+        },
+        "author": {
+            "type": "generated",
+            "generator": "coalesce",
+            "parameters": {
+                "sourceVariableName": "WindowsUserName",
+                "fallbackVariableName": "UnixUserName",
+                "defaultValue": "Omanimi"
+            },
+            "replaces": "Omanimi"
         }
     },
     "tags": {

--- a/Projektimallit/Jypeli.Templates/content/Peruspeli/.template.config/template.json
+++ b/Projektimallit/Jypeli.Templates/content/Peruspeli/.template.config/template.json
@@ -1,12 +1,30 @@
 {
+    "$schema": "http://json.schemastore.org/template",
     "author": "University of Jyväskylä",
-    "classifications": [
-        "Jypeli"
-    ],
+    "classifications": ["Jypeli"],
     "name": "Peruspeli",
     "identity": "Jypeli.Peruspeli",
     "groupIdentity": "Jypeli.Peruspeli",
     "shortName": "Peruspeli",
+    "symbols": {
+        "framework": {
+            "type": "parameter",
+            "description": "Käytettävä .NET-versio.",
+            "datatype": "choice",
+            "defaultValue": "net7.0",
+            "replaces": "net7.0",
+            "choices": [
+                {
+                    "choice": "net7.0",
+                    "description": "Käytä .NET 7"
+                },
+                {
+                    "choice": "net6.0",
+                    "description": "Käytä .NET 6"
+                }
+            ]
+        }
+    },
     "tags": {
         "language": "C#",
         "type": "project"
@@ -17,6 +35,6 @@
         }
     ],
     "sourceName": "Peruspeli",
-    "preferNameDirectory": "true",
+    "preferNameDirectory": true,
     "description": "Peli ilman fysiikkaa."
 }

--- a/Projektimallit/Jypeli.Templates/content/Peruspeli/Peruspeli.cs
+++ b/Projektimallit/Jypeli.Templates/content/Peruspeli/Peruspeli.cs
@@ -7,6 +7,11 @@ using Jypeli.Widgets;
 
 namespace Peruspeli;
 
+/// @author Omanimi
+/// @version Päivämäärä
+/// <summary>
+/// 
+/// </summary>
 public class Peruspeli : Game
 {
     public override void Begin()

--- a/Projektimallit/Jypeli.Templates/content/Tasohyppely/.template.config/template.json
+++ b/Projektimallit/Jypeli.Templates/content/Tasohyppely/.template.config/template.json
@@ -23,6 +23,34 @@
                     "description": "Käytä .NET 6"
                 }
             ]
+        },
+        "version": {
+            "type": "generated",
+            "generator": "now",
+            "parameters": {
+                "format": "dd.MM.yyyy"
+            },
+            "replaces": "Päivämäärä"
+        },
+        "WindowsUserName": {
+            "type": "bind",
+            "binding": "env:USERNAME",
+            "defaultValue": "Omanimi"
+        },
+        "UnixUserName": {
+            "type": "bind",
+            "binding": "env:USER",
+            "defaultValue": "Omanimi"
+        },
+        "author": {
+            "type": "generated",
+            "generator": "coalesce",
+            "parameters": {
+                "sourceVariableName": "WindowsUserName",
+                "fallbackVariableName": "UnixUserName",
+                "defaultValue": "Omanimi"
+            },
+            "replaces": "Omanimi"
         }
     },
     "tags": {

--- a/Projektimallit/Jypeli.Templates/content/Tasohyppely/.template.config/template.json
+++ b/Projektimallit/Jypeli.Templates/content/Tasohyppely/.template.config/template.json
@@ -1,12 +1,30 @@
 {
+    "$schema": "http://json.schemastore.org/template",
     "author": "University of Jyväskylä",
-    "classifications": [
-        "Jypeli"
-    ],
+    "classifications": ["Jypeli"],
     "name": "Tasohyppelypeli",
     "identity": "Jypeli.Tasohyppelypeli",
     "groupIdentity": "Jypeli.Tasohyppelypeli",
     "shortName": "Tasohyppelypeli",
+    "symbols": {
+        "framework": {
+            "type": "parameter",
+            "description": "Käytettävä .NET-versio.",
+            "datatype": "choice",
+            "defaultValue": "net7.0",
+            "replaces": "net7.0",
+            "choices": [
+                {
+                    "choice": "net7.0",
+                    "description": "Käytä .NET 7"
+                },
+                {
+                    "choice": "net6.0",
+                    "description": "Käytä .NET 6"
+                }
+            ]
+        }
+    },
     "tags": {
         "language": "C#",
         "type": "project"
@@ -17,6 +35,6 @@
         }
     ],
     "sourceName": "Tasohyppelypeli",
-    "preferNameDirectory": "true",
+    "preferNameDirectory": true,
     "description": "Peli jossa on valmiina tasohyppelyhahmo ja tasoja. Käyttää FarseerPhysics-fysiikkamoottoria."
 }

--- a/Projektimallit/Jypeli.Templates/content/Tasohyppely/Tasohyppelypeli.cs
+++ b/Projektimallit/Jypeli.Templates/content/Tasohyppely/Tasohyppelypeli.cs
@@ -7,6 +7,11 @@ using Jypeli.Widgets;
 
 namespace Tasohyppelypeli;
 
+/// @author Omanimi
+/// @version Päivämäärä
+/// <summary>
+/// 
+/// </summary>
 public class Tasohyppelypeli : PhysicsGame
 {
     private const double NOPEUS = 200;


### PR DESCRIPTION
Lisää muutaman symbolin templateen:

- Framework-valitsin sekä siihen `net6.0` ja `net7.0` -arvot. Jotkut IDEt (esim. Rider) tunnistavat valitsimen jopa osaavat automaattisesti valita oikean version sen perusteella, mikä .NET on käyttäjällä asennettu:

    ![image](https://github.com/Jypeli-JYU/Jypeli/assets/5202606/b153a632-12d0-41c6-b93c-ccf66ed2d4c3)

- ConsoleMainiin lisätty symbolit käyttäjänimen ja version generointiin. Eli `@version` ja `@author` täyttyvät nyt automaattisesti oikealla arvolla.
  - Huom: Riderissa jostain syystä `@author` ei vielä toimi, mutta `dotnet new` tuottaa oikean tulosteen. Ilmeisimmin on Riderin vika, mutta se ei suuria murheita aiheuta.

Lisäksi määritin templateille oikean skeeman ja korjasin sen perusteella `preferNameDirectory` käyttämään oikeaa tyyppiä.